### PR TITLE
[14] Unread conversations fixes

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Conversation < ApplicationRecord
-  has_many :messages, -> { order :created_at }, dependent: :destroy, inverse_of: :conversation
+  has_many :messages, dependent: :destroy
 
   belongs_to :target
   belongs_to :initiator, class_name: 'User'

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Conversation, type: :model do
   subject { create :conversation }
 
   describe 'associations' do
-    it { should have_many(:messages).dependent(:destroy) }
-    it { should belong_to(:target) }
-    it { should belong_to(:initiator) }
+    it { is_expected.to have_many(:messages).dependent(:destroy) }
+    it { is_expected.to belong_to(:target) }
+    it { is_expected.to belong_to(:initiator) }
   end
 
   describe 'validations' do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -4,11 +4,11 @@ require 'rails_helper'
 
 RSpec.describe Message, type: :model do
   describe 'associations' do
-    it { should belong_to(:conversation) }
-    it { should belong_to(:user) }
+    it { is_expected.to belong_to(:conversation) }
+    it { is_expected.to belong_to(:user) }
   end
 
   describe 'validations' do
-    it { should validate_presence_of(:text) }
+    it { is_expected.to validate_presence_of(:text) }
   end
 end

--- a/spec/models/target_spec.rb
+++ b/spec/models/target_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe Target, type: :model do
   subject { build :target }
 
   describe 'associations' do
-    it { should belong_to(:topic) }
-    it { should belong_to(:user) }
+    it { is_expected.to belong_to(:topic) }
+    it { is_expected.to belong_to(:user) }
   end
 
   describe 'validations' do
-    it { should validate_presence_of(:title) }
-    it { should validate_presence_of(:lat) }
-    it { should validate_presence_of(:lng) }
-    it { should validate_numericality_of(:area_length).is_greater_than(0) }
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:lat) }
+    it { is_expected.to validate_presence_of(:lng) }
+    it { is_expected.to validate_numericality_of(:area_length).is_greater_than(0) }
 
     context 'user must have less than 10 targets' do
       let(:target) { build :target, user: user }

--- a/spec/models/topic_spec.rb
+++ b/spec/models/topic_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe Topic, type: :model do
   subject { create :topic }
 
   describe 'associations' do
-    it { should have_many(:targets) }
+    it { is_expected.to have_many(:targets) }
   end
 
   describe 'validations' do
-    it { should validate_presence_of(:name) }
-    it { should validate_uniqueness_of(:name) }
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_uniqueness_of(:name) }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe User, type: :model do
   subject { create :user }
 
   describe 'associations' do
-    it { should have_many(:targets).dependent(:destroy) }
+    it { is_expected.to have_many(:targets).dependent(:destroy) }
   end
 
   describe '#compatible_targets' do


### PR DESCRIPTION
- Using `is_expected.to` instead of `should`
- Removing unneeded option `inverse_of` in conversation model
- Removing unneeded scope in conversation model

Fixing comments from #22 