### PR TITLE
[33] Removing unneeded param from conversation's create endpoint

### DIFF
--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -7,8 +7,8 @@ class ConversationsController < ApplicationController
     conversation = ConversationService.call(conversation_params.merge(current_user: current_user))
 
     render json: conversation, status: :created if conversation.save!
-  rescue ConversationNotAllowedError => e
-    render_not_found(e)
+  rescue ConversationWithSameUserError => _e
+    render_error(:bad_request, I18n.t('errors.conversation_with_same_user_error'))
   end
 
   def index
@@ -30,7 +30,7 @@ class ConversationsController < ApplicationController
   end
 
   def conversation_params
-    params.require(:conversation).permit(:target_id, :initiator_id)
+    params.require(:conversation).permit(:target_id)
   end
 
   def conversation_update_params

--- a/app/errors/conversation_not_allowed_error.rb
+++ b/app/errors/conversation_not_allowed_error.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class ConversationNotAllowedError < StandardError
-end

--- a/app/errors/conversation_with_same_user_error.rb
+++ b/app/errors/conversation_with_same_user_error.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ConversationWithSameUserError < StandardError
+end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -6,6 +6,7 @@ class Conversation < ApplicationRecord
   belongs_to :target
   belongs_to :initiator, class_name: 'User'
 
+  validates :target, uniqueness: { scope: :initiator_id }
   validate :target_must_be_compatible_with_initiator
 
   def unread?(user)

--- a/app/services/conversation_service.rb
+++ b/app/services/conversation_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ConversationService
-  attr_reader :current_user, :initiator_id, :target_id
+  attr_reader :current_user, :target_id
 
   def self.call(args)
     new(args).build
@@ -9,20 +9,19 @@ class ConversationService
 
   def initialize(args)
     @current_user = args[:current_user]
-    @initiator_id = args[:initiator_id].to_i
     @target_id = args[:target_id]
   end
 
   def build
-    raise ConversationNotAllowedError unless valid?
+    raise ConversationWithSameUserError unless valid?
 
-    Conversation.first_or_initialize target_id: target_id, initiator_id: initiator_id
+    Conversation.new target_id: target_id, initiator_id: current_user.id
   end
 
   private
 
   def valid?
-    current_user.id == initiator_id || current_user.targets.include?(target)
+    !current_user.targets.include?(target)
   end
 
   def target

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,8 @@ en:
   user_must_have_less_than_maximum_targets: "User must have less than %{max} targets"
   target_must_be_compatible_with_initiator: "must be compatible with initiator"
   errors:
-    server: 'An error ocurred'
-    not_found: "Couldn't find the record"
-    missing_param: 'A required param is missing'
+    conversation_with_same_user_error: "Can't start a conversation with yourself"
     invalid_content_type: 'Invalid content type header'
+    missing_param: 'A required param is missing'
+    not_found: "Couldn't find the record"
+    server: 'An error ocurred'

--- a/spec/acceptance/conversations_spec.rb
+++ b/spec/acceptance/conversations_spec.rb
@@ -9,11 +9,7 @@ resource 'Conversations' do
   header 'uid', :uid_header
 
   let(:conversation) { create :conversation }
-  let(:conversation_with_messages) do
-    create :conversation_with_messages, initiator: conversation.initiator,
-                                        target: conversation.target
-  end
-  let(:user) { conversation.initiator }
+  let(:conversation_with_messages) { create :conversation_with_messages }
 
   before { create_list :conversation, 3, initiator: user }
 
@@ -21,11 +17,11 @@ resource 'Conversations' do
     post 'Create' do
       with_options scope: :conversation, required: true do
         attribute :target_id, 'Target associated to the conversation'
-        attribute :initiator_id, 'ID of the user whom initiated the conversation'
       end
 
+      let(:user) { create :user_with_targets }
+      let(:conversation) { build :conversation, initiator: user }
       let(:target_id) { conversation.target_id }
-      let(:initiator_id) { conversation.initiator_id }
 
       example 'Ok' do
         do_request
@@ -35,6 +31,8 @@ resource 'Conversations' do
     end
 
     get 'Index' do
+      let(:user) { conversation.initiator }
+
       example 'Ok' do
         do_request
 
@@ -44,6 +42,7 @@ resource 'Conversations' do
   end
 
   route '/conversations/:id', 'Conversation member' do
+    let(:user) { conversation_with_messages.initiator }
     let(:id) { conversation_with_messages.id }
 
     get 'Show' do
@@ -55,6 +54,8 @@ resource 'Conversations' do
     end
 
     put 'Update' do
+      let(:user) { conversation_with_messages.initiator }
+
       with_options scope: :conversation, required: true do
         attribute :unread, 'Flag to mark the conversation as unread'
       end

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Conversation, type: :model do
   describe 'validations' do
     subject { create :conversation }
 
+    it { is_expected.to validate_uniqueness_of(:target).scoped_to(:initiator_id) }
+
     context 'has a target compatible with the initiator' do
       context 'conversation valid' do
         it 'is valid' do

--- a/spec/services/conversation_service_spec.rb
+++ b/spec/services/conversation_service_spec.rb
@@ -6,12 +6,10 @@ RSpec.describe 'ConversationService' do
   let(:args) do
     {
       current_user: current_user,
-      initiator_id: initiator_id,
       target_id: target_id
     }
   end
   let(:current_user) { user }
-  let(:initiator_id) { user.id }
   let(:lat) { user.targets.first.lat }
   let(:lng) { user.targets.first.lng }
   let(:target) { create :target, lat: lat, lng: lng, topic: topic }
@@ -22,26 +20,15 @@ RSpec.describe 'ConversationService' do
   subject { ConversationService.call(args) }
 
   context 'building a conversation' do
-    context 'as the initiator' do
-      it 'returns a new conversation record' do
-        expect(subject.new_record?).to eq true
-      end
+    it 'returns a new conversation record' do
+      expect(subject.new_record?).to eq true
     end
 
-    context 'as a the receiver' do
-      let(:initiator_id) { target.user.id }
-      let(:target_id) { user.targets.first.id }
-
-      it 'returns a new conversation record' do
-        expect(subject.new_record?).to eq true
-      end
-    end
-
-    context 'as a user not related to the target or the initiator' do
-      let(:current_user) { create :user_with_targets }
+    context 'as a user owning the target' do
+      let(:target) { current_user.targets.first }
 
       it 'raises an error' do
-        expect { subject }.to raise_error ConversationNotAllowedError
+        expect { subject }.to raise_error ConversationWithSameUserError
       end
     end
   end


### PR DESCRIPTION
- Removed initiator_id in favor of using current_user data